### PR TITLE
feat: docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### docker ###
+.env
+db_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.2'
+
+services:
+  mysql-db:
+    image: mysql
+    restart: always
+    env_file: ./.env
+    ports:
+      - $MYSQLDB_LOCAL_PORT:$MYSQLDB_DOCKER_PORT
+    environment:
+      - MYSQL_DATABASE=$MYSQLDB_DATABASE
+      - MYSQL_ROOT_PASSWORD=$MYSQLDB_ROOT_PASSWORD
+      - TZ=Asia/Seoul
+    volumes:
+      - ./db_data:/var/lib/mysql
+
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    env_file: ./.env
+    ports:
+      - $ZOOKEEPER_LOCAL_PORT:$ZOOKEEPER_DOCKER_PORT
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+
+  kafka:
+    image: bitnami/kafka:2.5.0
+    env_file: ./.env
+    ports:
+      - $KAFKA_LOCAL_PORT:$KAFKA_DOCKER_PORT
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:$ZOOKEEPER_DOCKER_PORT
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:$KAFKA_DOCKER_PORT
+#      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:$KAFKA_DOCKER_PORT,PLAINTEXT_HOST://localhost:$KAFKA_LOCAL_PORT
+#      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      - KAFKA_LISTENERS=PLAINTEXT://:$KAFKA_DOCKER_PORT
+      - KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    depends_on:
+      - zookeeper

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <!--Kafka-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # Mysql ??
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # DB Source URL
-spring.datasource.url=jdbc:mysql://localhost:3306/test?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul
+spring.datasource.url=jdbc:mysql://localhost:13306/test?allowPublicKeyRetrieval=true&useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul
 # DB username
 spring.datasource.username=root
 # DB password

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,14 @@ loggin:
 spring:
   profiles:
     include: jwt
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:9092
+      group-id: group-id-oing
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
## docker-compose.yml
- 프로젝트 루트 경로에서 `docker-compose up` 명령어 ->  mysql, kafka, zookeeper 환경 구축됨
  - docker mysql 포트를 13360으로 설정했습니다. (로컬 db와 충돌 막기 위함)
 
## application.properties
- docker mysql에 연결되도록 port를 `3306` -> `13306` 으로 변경했습니다.
-  드라비어 환경설정 추가 : `allowPublicKeyRetrieval=true`.

추가적으로 properties 파일없애고 yml로 통일하는게 어떤가요?

## .env 파일
gitignore되어 있기 때문에 노션에 따로 올리겠습니다. 
.env 파일은 docker-compose.yml 파일과 같은 경로에 둬야 합니다.
그리고 mysql password, user는 기존 설정대로 해놨습니다. 나중에 노션에 있는 id, pw로 변경해야 할것같아요


## 참고
- https://insertafter.com/en/blog/kafka_docker_compose.html
- https://www.bezkoder.com/docker-compose-spring-boot-mysql/