### PR TITLE
fix: disable restart kafakaListener

### DIFF
--- a/src/main/java/com/example/sendowl/kafka/consumer/KafkaConsumer.java
+++ b/src/main/java/com/example/sendowl/kafka/consumer/KafkaConsumer.java
@@ -21,7 +21,7 @@ public class KafkaConsumer {
 
     private final MailService mailService;
 
-    @KafkaListener(topics = EMAIL_VERIFICATION, groupId = NOTIFY_EMAIL_VERIFICATION)
+    @KafkaListener(topics = EMAIL_VERIFICATION, groupId = NOTIFY_EMAIL_VERIFICATION, autoStartup = "${listen.auto.start:false}")
     public void sendEmailValidation(EmailVerifyDto dto) {
         new Thread(() -> {
             try {


### PR DESCRIPTION
카프카의 자동 재실행을 막아서 불필요한 로그 생성 막아놓음